### PR TITLE
Allow partial signature verification

### DIFF
--- a/cli/src/multisig.rs
+++ b/cli/src/multisig.rs
@@ -203,7 +203,9 @@ impl MultiSig {
         assert!(verify_partial_signature(
             public_keys,
             aggregated_commitment,
+            b,
             &self.public_key(),
+            own_commitment_pairs.iter().map(|pair| *pair.commitment()).collect(),
             &partial_signature,
             data
         ));


### PR DESCRIPTION
We can verify partial signatures using public inputs as follows:
<img width="330" alt="formula" src="https://user-images.githubusercontent.com/13586855/186137921-1eecd98c-9262-485e-837b-2e129ebcd18b.png">

`g` is the ed25519 base point
`s_i` is the partial signature
`pk_i` is the corresponding public key
`a_i` is the hash `H(pks, pk_i)` where `pks` denotes the vector of all public keys
`c` is the hash `H(apk, R, m)` where `apk` is the aggregated public key, `R` is the aggregated commitment, `m` is the message
`R_{i,k}` is the k'th commitment
`b` is the hash `H(apk, (R_1,...,R_n), m)` where `R_j` denotes an intermediate aggregated commitment